### PR TITLE
Fix V3107

### DIFF
--- a/src/Evaluate.cs
+++ b/src/Evaluate.cs
@@ -680,7 +680,7 @@ namespace Portfish
                                 (((((0xAA55AA55AA55AA55UL & Utils.SquareBB[s]) != 0) ? 0xAA55AA55AA55AA55UL : ~0xAA55AA55AA55AA55UL) & (pos.byTypeBB[PieceTypeC.BISHOP] & pos.byColorBB[Them])) == 0)
                                 )
                             {
-                                bonus += bonus + bonus / 2;
+                                bonus += bonus;
                             }
                             else
                             {


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Identical expression 'bonus' to the left and to the right of compound assignment. PortfishNet45 Evaluate.cs 683